### PR TITLE
Fragments instead of query params

### DIFF
--- a/wsd-frontend/src/app/(app)/posts/[hex]/page.tsx
+++ b/wsd-frontend/src/app/(app)/posts/[hex]/page.tsx
@@ -6,23 +6,19 @@ import _ from 'lodash'
 
 import { Button, buttonVariants } from '@/components/shadcn/button'
 import { Overlay, OverlayClose, OverlayContent, OverlayTitle, OverlayTrigger } from '@/components/shadcn/overlay'
+import { ScrollToHashContainer } from '@/components/shadcn/scroll-to-hash-container'
 import { Separator } from '@/components/shadcn/separator'
 import AuthenticatedOnlyActionButton from '@/components/wsd/AuthenticatedOnlyActionButton'
 import Meme from '@/components/wsd/Meme'
-import { MemeCommentList } from '@/components/wsd/MemeComment'
+import MemeComment from '@/components/wsd/MemeComment'
 import NewComment from '@/components/wsd/NewComment'
 
 import { APIQuery, APIType, includesType } from '@/api'
-import { includesTypeArray } from '@/api/typeHelpers'
 import config from '@/config'
 import { getWSDMetadata } from '@/lib/metadata'
 import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
 import { getKeys } from '@/lib/typeHelpers'
 import { InvalidHEXError, cn, hexToUUIDv4, suppress } from '@/lib/utils'
-
-interface APIQueryPostComments extends APIQuery<'/v0/post-comments/'> {
-  scrollToComments?: boolean
-}
 
 export async function generateMetadata(props: { params: Promise<{ hex: string }> }): Promise<Metadata | undefined> {
   const params = await props.params
@@ -44,7 +40,7 @@ export async function generateMetadata(props: { params: Promise<{ hex: string }>
 
 export default async function PostPage(props: {
   params: Promise<{ hex: string }>
-  searchParams: Promise<APIQueryPostComments>
+  searchParams: Promise<APIQuery<'/v0/post-comments/'>>
 }) {
   const searchParams = await props.searchParams
   const params = await props.params
@@ -117,12 +113,14 @@ export default async function PostPage(props: {
               </div>
             )}
             {isAuthenticated && <NewComment post={post_} />}
-            {wsd.hasResults(comments) && (
-              <MemeCommentList
-                comments={includesTypeArray(comments.results, 'user', 'User')}
-                scrollToComments={searchParams.scrollToComments}
-              />
-            )}
+            <ScrollToHashContainer hash="comments">
+              <div className="flex flex-col justify-center items-start">
+                {wsd.hasResults(comments) &&
+                  comments.results.map((comment) => (
+                    <MemeComment comment={includesType(comment, 'user', 'User')} key={`meme-comment-${comment.id}`} />
+                  ))}
+              </div>
+            </ScrollToHashContainer>
           </div>
         </div>
       )

--- a/wsd-frontend/src/components/shadcn/scroll-to-hash-container.tsx
+++ b/wsd-frontend/src/components/shadcn/scroll-to-hash-container.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useRef, PropsWithChildren } from 'react'
+
+type ScrollToHashContainerProps = PropsWithChildren<{
+  hash: string
+  offset?: number
+}>
+
+function ScrollToHashContainer({ hash, offset = 0, children }: ScrollToHashContainerProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const shouldScroll = window.location.hash === `#${hash}`
+    if (shouldScroll && ref.current) {
+      requestAnimationFrame(() => {
+        if (!ref.current) return
+        const top = ref.current.offsetTop - offset
+        window.scrollTo({ top, behavior: 'smooth' })
+      })
+    }
+  }, [hash])
+
+  return (
+    <div ref={ref}>  {/* Adding id here causes the browser's auto scroll behavior to kick in */}
+      {children}
+    </div>
+  )
+}
+
+export { ScrollToHashContainer }

--- a/wsd-frontend/src/components/wsd/Meme/client/FeedbackButtons.tsx
+++ b/wsd-frontend/src/components/wsd/Meme/client/FeedbackButtons.tsx
@@ -116,9 +116,7 @@ export default function FeedbackButtons({
       <Link
         href={{
           pathname: `/posts/${uuidV4toHEX(post.id)}`,
-          query: {
-            scrollToComments: true,
-          },
+          hash: 'comments',
         }}
         className={cn(
           buttonVariants({

--- a/wsd-frontend/src/components/wsd/MemeComment/MemeComment.tsx
+++ b/wsd-frontend/src/components/wsd/MemeComment/MemeComment.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import * as Icons from 'lucide-react'
 
@@ -16,35 +16,6 @@ import { cn, shortFormattedDateTime } from '@/lib/utils'
 
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
-
-export function MemeCommentList({
-  comments,
-  scrollToComments = false,
-}: {
-  comments: Includes<APIType<'PostComment'>, 'user', APIType<'User'>>[]
-  scrollToComments?: boolean
-}) {
-  const listRef = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (scrollToComments && listRef.current && comments.length > 0) {
-      requestAnimationFrame(() => {
-        if (!listRef.current) return
-        window.scrollTo({
-          top: listRef.current.offsetTop, // 16px additional padding
-          behavior: 'smooth',
-        })
-      })
-    }
-  }, [comments, scrollToComments])
-
-  return (
-    <div className="flex flex-col justify-center items-start" ref={listRef}>
-      {comments.map((comment) => (
-        <MemeComment key={comment.id} comment={comment} />
-      ))}
-    </div>
-  )
-}
 
 export function MemeComment({ comment }: { comment: Includes<APIType<'PostComment'>, 'user', APIType<'User'>> }) {
   const wsd = useWSDAPI()

--- a/wsd-frontend/src/components/wsd/MemeComment/index.ts
+++ b/wsd-frontend/src/components/wsd/MemeComment/index.ts
@@ -1,1 +1,1 @@
-export { MemeComment as default, MemeCommentList } from './MemeComment'
+export { MemeComment as default } from './MemeComment'


### PR DESCRIPTION
- Tried to use #hash/fragment syntax 
- Made the scroll part reusable
- No extra app component needed (because of the reusable component) 

Kinda removed some of your changes but moved the core feature you have into a new component, didn't want to merge this without asking if this works for you too because you mentioned fragments didn't work for you for some reason, can you check if this works for you and then we can merge this to yours and yours back to master? 